### PR TITLE
Thaleia: spec仕様書ビューアとマークダウンレンダラー

### DIFF
--- a/unity/Assets/Musa/MusaDocumentBrowser.cs
+++ b/unity/Assets/Musa/MusaDocumentBrowser.cs
@@ -1,0 +1,139 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// spec/ ディレクトリのスキャンとファイルマッピングを担う共通ユーティリティ
+/// NOTE: MusaDocumentTab / MusaDocumentWindow から利用
+/// </summary>
+public static class MusaDocumentBrowser
+{
+    public class DocTreeNode
+    {
+        public string Name;
+        public string FullPath;
+        public bool IsDirectory;
+        public List<DocTreeNode> Children = new List<DocTreeNode>();
+        public bool IsExpanded;
+    }
+
+    // NOTE: スクリプト名 → .md フルパス のマッピングキャッシュ
+    private static Dictionary<string, string> scriptToDocMap;
+
+    /// <summary>
+    /// spec/ ディレクトリの絶対パスを取得
+    /// NOTE: Application.dataPath (= unity/Assets) から ../../spec で到達
+    /// </summary>
+    public static string GetSpecRootPath()
+    {
+        return Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..", "spec"));
+    }
+
+    /// <summary>
+    /// 指定ディレクトリ配下を再帰的にスキャンしてツリー構築
+    /// </summary>
+    public static List<DocTreeNode> BuildFileTree(string rootPath)
+    {
+        var nodes = new List<DocTreeNode>();
+        if (!Directory.Exists(rootPath)) return nodes;
+
+        // NOTE: ディレクトリ
+        foreach (var dir in Directory.GetDirectories(rootPath))
+        {
+            var dirNode = new DocTreeNode
+            {
+                Name = Path.GetFileName(dir),
+                FullPath = dir,
+                IsDirectory = true,
+                Children = BuildFileTree(dir)
+            };
+            // NOTE: 空ディレクトリはスキップ
+            if (dirNode.Children.Count > 0)
+                nodes.Add(dirNode);
+        }
+
+        // NOTE: .md ファイル
+        foreach (var file in Directory.GetFiles(rootPath, "*.md"))
+        {
+            nodes.Add(new DocTreeNode
+            {
+                Name = Path.GetFileName(file),
+                FullPath = file,
+                IsDirectory = false
+            });
+        }
+
+        return nodes;
+    }
+
+    /// <summary>
+    /// スクリプト名に対応する仕様書パスを検索
+    /// NOTE: 複数マッチ時は spec/code/ 配下を優先
+    /// </summary>
+    public static string FindDocForScript(string scriptName)
+    {
+        if (string.IsNullOrEmpty(scriptName)) return null;
+        if (scriptToDocMap == null) RefreshCache();
+        if (scriptToDocMap == null) return null;
+
+        scriptToDocMap.TryGetValue(scriptName, out var path);
+        return path;
+    }
+
+    /// <summary>
+    /// .md ファイルの内容を読み込み
+    /// </summary>
+    public static string ReadDocContent(string mdPath)
+    {
+        if (string.IsNullOrEmpty(mdPath) || !File.Exists(mdPath)) return null;
+        return File.ReadAllText(mdPath);
+    }
+
+    /// <summary>
+    /// spec/ を再スキャンしてマッピング辞書を再構築
+    /// </summary>
+    public static void RefreshCache()
+    {
+        scriptToDocMap = new Dictionary<string, string>();
+        var specRoot = GetSpecRootPath();
+        if (!Directory.Exists(specRoot)) return;
+
+        var codePath = Path.Combine(specRoot, "code");
+        var allMdFiles = Directory.GetFiles(specRoot, "*.md", SearchOption.AllDirectories);
+
+        foreach (var mdFile in allMdFiles)
+        {
+            var key = Path.GetFileNameWithoutExtension(mdFile);
+            if (scriptToDocMap.ContainsKey(key))
+            {
+                // NOTE: spec/code/ 配下を優先
+                if (mdFile.Replace('\\', '/').Contains("/code/"))
+                    scriptToDocMap[key] = mdFile;
+            }
+            else
+            {
+                scriptToDocMap[key] = mdFile;
+            }
+        }
+    }
+
+    /// <summary>
+    /// spec/ 直下のカテゴリ（ディレクトリ名）リストを返却
+    /// </summary>
+    public static string[] GetCategories()
+    {
+        var specRoot = GetSpecRootPath();
+        if (!Directory.Exists(specRoot)) return new string[0];
+
+        var dirs = Directory.GetDirectories(specRoot);
+        var categories = new List<string>();
+        foreach (var dir in dirs)
+        {
+            categories.Add(Path.GetFileName(dir));
+        }
+        categories.Sort();
+        return categories.ToArray();
+    }
+}
+#endif

--- a/unity/Assets/Musa/MusaDocumentBrowser.cs.meta
+++ b/unity/Assets/Musa/MusaDocumentBrowser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 15bbb219862093742a95d4153bad0ade

--- a/unity/Assets/Musa/MusaDocumentExplorer.cs
+++ b/unity/Assets/Musa/MusaDocumentExplorer.cs
@@ -1,0 +1,218 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Document Explorer — spec/ 配下の仕様書をツリー表示・Thaleia描画するスタンドアロンウインドウ
+/// </summary>
+public class MusaDocumentExplorer : EditorWindow
+{
+    private List<MusaDocumentBrowser.DocTreeNode> fileTree = new List<MusaDocumentBrowser.DocTreeNode>();
+    private int selectedCategoryIndex = -1;
+    private string[] categoryNames;
+    private string selectedFilePath;
+    private string fileContent;
+    private Vector2 sidebarScrollPosition;
+    private Vector2 treeScrollPosition;
+    private Vector2 contentScrollPosition;
+    private ThaleiaRenderer thaleiaRenderer = new ThaleiaRenderer();
+
+    private const float SidebarWidth = 100f;
+    private const float TreePaneWidth = 180f;
+
+    // NOTE: GUIStyleキャッシュ
+    private GUIStyle sidebarButtonStyle;
+    private GUIStyle sidebarActiveButtonStyle;
+    private bool stylesInitialized;
+
+    [MenuItem("Musa/Document Explorer")]
+    public static void ShowWindow()
+    {
+        var window = GetWindow<MusaDocumentExplorer>("Document Explorer");
+        window.minSize = new Vector2(600, 400);
+    }
+
+    private void OnEnable()
+    {
+        MusaDocumentBrowser.RefreshCache();
+        categoryNames = MusaDocumentBrowser.GetCategories();
+    }
+
+    private void InitStyles()
+    {
+        if (stylesInitialized) return;
+
+        sidebarButtonStyle = new GUIStyle(GUI.skin.button)
+        {
+            alignment = TextAnchor.MiddleLeft,
+            padding = new RectOffset(10, 4, 6, 6),
+            fixedHeight = 30
+        };
+
+        sidebarActiveButtonStyle = new GUIStyle(sidebarButtonStyle)
+        {
+            fontStyle = FontStyle.Bold
+        };
+        sidebarActiveButtonStyle.normal.textColor = new Color(0.3f, 0.8f, 1f);
+
+        stylesInitialized = true;
+    }
+
+    private void OnGUI()
+    {
+        InitStyles();
+
+        EditorGUILayout.BeginHorizontal();
+
+        // NOTE: 左サイドバー — カテゴリ一覧
+        EditorGUILayout.BeginVertical(GUILayout.Width(SidebarWidth));
+        DrawCategorySidebar();
+        EditorGUILayout.EndVertical();
+
+        // NOTE: セパレーター
+        var sep1 = EditorGUILayout.GetControlRect(false, GUILayout.Width(1));
+        EditorGUI.DrawRect(sep1, new Color(0.3f, 0.3f, 0.3f));
+
+        // NOTE: 中央ペイン — ファイルツリー
+        EditorGUILayout.BeginVertical(GUILayout.Width(TreePaneWidth));
+        DrawFileTreePane();
+        EditorGUILayout.EndVertical();
+
+        // NOTE: セパレーター
+        var sep2 = EditorGUILayout.GetControlRect(false, GUILayout.Width(1));
+        EditorGUI.DrawRect(sep2, new Color(0.3f, 0.3f, 0.3f));
+
+        // NOTE: 右ペイン — ドキュメント内容
+        EditorGUILayout.BeginVertical();
+        DrawContentPane();
+        EditorGUILayout.EndVertical();
+
+        EditorGUILayout.EndHorizontal();
+    }
+
+    // =====================================================================
+    // カテゴリサイドバー
+    // =====================================================================
+
+    private void DrawCategorySidebar()
+    {
+        EditorGUILayout.LabelField("Categories", EditorStyles.boldLabel);
+        EditorGUILayout.Space(4);
+
+        if (categoryNames == null || categoryNames.Length == 0)
+        {
+            EditorGUILayout.HelpBox("spec/ が見つかりません", MessageType.Warning);
+            return;
+        }
+
+        sidebarScrollPosition = EditorGUILayout.BeginScrollView(sidebarScrollPosition);
+        for (int i = 0; i < categoryNames.Length; i++)
+        {
+            var style = i == selectedCategoryIndex ? sidebarActiveButtonStyle : sidebarButtonStyle;
+            if (GUILayout.Button(categoryNames[i], style))
+            {
+                SelectCategory(i);
+            }
+        }
+        EditorGUILayout.EndScrollView();
+
+        GUILayout.FlexibleSpace();
+
+        if (GUILayout.Button("Refresh", GUILayout.Height(24)))
+        {
+            MusaDocumentBrowser.RefreshCache();
+            categoryNames = MusaDocumentBrowser.GetCategories();
+            if (selectedCategoryIndex >= 0)
+                SelectCategory(selectedCategoryIndex);
+        }
+    }
+
+    private void SelectCategory(int index)
+    {
+        if (index < 0 || categoryNames == null || index >= categoryNames.Length) return;
+        if (selectedCategoryIndex == index) return;
+
+        selectedCategoryIndex = index;
+        var specRoot = MusaDocumentBrowser.GetSpecRootPath();
+        var categoryPath = Path.Combine(specRoot, categoryNames[index]);
+        fileTree = MusaDocumentBrowser.BuildFileTree(categoryPath);
+
+        selectedFilePath = null;
+        fileContent = null;
+        treeScrollPosition = Vector2.zero;
+        contentScrollPosition = Vector2.zero;
+    }
+
+    // =====================================================================
+    // ファイルツリーペイン
+    // =====================================================================
+
+    private void DrawFileTreePane()
+    {
+        EditorGUILayout.LabelField("Files", EditorStyles.boldLabel);
+        EditorGUILayout.Space(2);
+
+        if (selectedCategoryIndex < 0)
+        {
+            EditorGUILayout.HelpBox("カテゴリを選択", MessageType.Info);
+            return;
+        }
+
+        treeScrollPosition = EditorGUILayout.BeginScrollView(treeScrollPosition);
+        DrawTreeNodes(fileTree);
+        EditorGUILayout.EndScrollView();
+    }
+
+    private void DrawTreeNodes(List<MusaDocumentBrowser.DocTreeNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            if (node.IsDirectory)
+            {
+                node.IsExpanded = EditorGUILayout.Foldout(node.IsExpanded, node.Name, true);
+                if (node.IsExpanded)
+                {
+                    EditorGUI.indentLevel++;
+                    DrawTreeNodes(node.Children);
+                    EditorGUI.indentLevel--;
+                }
+            }
+            else
+            {
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Space(EditorGUI.indentLevel * 15f);
+
+                bool isSelected = selectedFilePath == node.FullPath;
+                var style = isSelected ? EditorStyles.boldLabel : EditorStyles.linkLabel;
+                if (GUILayout.Button(node.Name, style, GUILayout.ExpandWidth(false)))
+                {
+                    selectedFilePath = node.FullPath;
+                    fileContent = MusaDocumentBrowser.ReadDocContent(node.FullPath);
+                    thaleiaRenderer.Parse(fileContent);
+                    contentScrollPosition = Vector2.zero;
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+        }
+    }
+
+    // =====================================================================
+    // ドキュメント内容ペイン
+    // =====================================================================
+
+    private void DrawContentPane()
+    {
+        if (string.IsNullOrEmpty(selectedFilePath))
+        {
+            EditorGUILayout.HelpBox("ファイルを選択してください", MessageType.Info);
+            return;
+        }
+
+        contentScrollPosition = EditorGUILayout.BeginScrollView(contentScrollPosition);
+        thaleiaRenderer.Draw();
+        EditorGUILayout.EndScrollView();
+    }
+}
+#endif

--- a/unity/Assets/Musa/MusaDocumentExplorer.cs.meta
+++ b/unity/Assets/Musa/MusaDocumentExplorer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c19d41c6671fa4f4b8694019631b9885

--- a/unity/Assets/Musa/MusaDocumentWindow.cs
+++ b/unity/Assets/Musa/MusaDocumentWindow.cs
@@ -1,0 +1,305 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// スタンドアロンドッキング可能ドキュメントウインドウ
+/// NOTE: Projectウインドウでのスクリプト選択、またはInspectorでのコンポーネントクリックに連動
+/// NOTE: 「インスペクタから自動更新」ON時は選択GameObjectの全コンポーネントをタブ表示
+/// </summary>
+public class MusaDocumentWindow : EditorWindow
+{
+    // =====================================================================
+    // インスペクタ自動更新
+    // =====================================================================
+    private bool autoUpdateFromInspector = true;
+
+    // NOTE: インスペクタ連動時のタブ情報
+    private class DocTab
+    {
+        public string ScriptName;
+        public string DocPath;
+        public string DocContent;
+        public ThaleiaRenderer Renderer = new ThaleiaRenderer();
+    }
+    private List<DocTab> docTabs = new List<DocTab>();
+    private int selectedTabIndex;
+    private string[] tabNames = new string[0];
+
+    // NOTE: 前回のGameObject識別用（不要な再スキャン防止）
+    private int lastGameObjectInstanceId;
+
+    // =====================================================================
+    // 手動選択（インスペクタ連動OFF / Specリンククリック時）
+    // =====================================================================
+    private string currentScriptName;
+    private string currentDocPath;
+    private string currentDocContent;
+    private ThaleiaRenderer singleRenderer = new ThaleiaRenderer();
+
+    private Vector2 scrollPosition;
+
+    [MenuItem("Musa/ドキュメント")]
+    public static void ShowWindow()
+    {
+        var window = GetWindow<MusaDocumentWindow>("ドキュメント");
+        window.minSize = new Vector2(300, 200);
+    }
+
+    private void OnEnable()
+    {
+        Selection.selectionChanged += OnSelectionChanged;
+        Editor.finishedDefaultHeaderGUI += OnInspectorHeaderGUI;
+        OnSelectionChanged();
+    }
+
+    private void OnDisable()
+    {
+        Selection.selectionChanged -= OnSelectionChanged;
+        Editor.finishedDefaultHeaderGUI -= OnInspectorHeaderGUI;
+    }
+
+    // =====================================================================
+    // 選択変更
+    // =====================================================================
+
+    private void OnSelectionChanged()
+    {
+        var activeObject = Selection.activeObject;
+
+        // NOTE: MonoScript選択（Project ウインドウ）
+        if (activeObject is MonoScript script)
+        {
+            SetSingleDocument(script.name);
+            return;
+        }
+
+        // NOTE: GameObject選択 → インスペクタ自動更新
+        if (autoUpdateFromInspector && activeObject is GameObject go)
+        {
+            RefreshFromGameObject(go);
+            return;
+        }
+    }
+
+    // =====================================================================
+    // インスペクタ自動更新: GameObjectのコンポーネントをスキャン
+    // =====================================================================
+
+    private void RefreshFromGameObject(GameObject go)
+    {
+        if (go == null) return;
+        if (go.GetInstanceID() == lastGameObjectInstanceId) return;
+        lastGameObjectInstanceId = go.GetInstanceID();
+
+        docTabs.Clear();
+        var components = go.GetComponents<Component>();
+
+        foreach (var component in components)
+        {
+            if (component == null) continue;
+
+            MonoScript script = null;
+            if (component is MonoBehaviour mb)
+                script = MonoScript.FromMonoBehaviour(mb);
+
+            if (script == null) continue;
+
+            var docPath = MusaDocumentBrowser.FindDocForScript(script.name);
+            if (string.IsNullOrEmpty(docPath)) continue;
+
+            var tab = new DocTab
+            {
+                ScriptName = script.name,
+                DocPath = docPath,
+                DocContent = MusaDocumentBrowser.ReadDocContent(docPath),
+            };
+            tab.Renderer.Parse(tab.DocContent);
+            docTabs.Add(tab);
+        }
+
+        // NOTE: タブ名配列を構築
+        tabNames = new string[docTabs.Count];
+        for (int i = 0; i < docTabs.Count; i++)
+            tabNames[i] = docTabs[i].ScriptName;
+
+        selectedTabIndex = 0;
+        scrollPosition = Vector2.zero;
+
+        // NOTE: タブモードに切替（手動選択をクリア）
+        currentScriptName = null;
+        currentDocPath = null;
+        currentDocContent = null;
+
+        Repaint();
+    }
+
+    // =====================================================================
+    // 手動選択: 単一ドキュメント表示
+    // =====================================================================
+
+    private void SetSingleDocument(string scriptName)
+    {
+        if (string.IsNullOrEmpty(scriptName)) return;
+        if (scriptName == currentScriptName) return;
+
+        // NOTE: タブモードを解除
+        docTabs.Clear();
+        tabNames = new string[0];
+        lastGameObjectInstanceId = 0;
+
+        currentScriptName = scriptName;
+        currentDocPath = MusaDocumentBrowser.FindDocForScript(scriptName);
+        if (!string.IsNullOrEmpty(currentDocPath))
+        {
+            currentDocContent = MusaDocumentBrowser.ReadDocContent(currentDocPath);
+            singleRenderer.Parse(currentDocContent);
+        }
+        else
+        {
+            currentDocContent = null;
+            singleRenderer.Parse(null);
+        }
+        scrollPosition = Vector2.zero;
+        Repaint();
+    }
+
+    // =====================================================================
+    // Inspectorヘッダーへの Spec リンク追加
+    // =====================================================================
+
+    private void OnInspectorHeaderGUI(Editor editor)
+    {
+        MonoScript script = null;
+        if (editor.target is MonoBehaviour mb)
+            script = MonoScript.FromMonoBehaviour(mb);
+        else if (editor.target is ScriptableObject so && !(so is EditorWindow))
+            script = MonoScript.FromScriptableObject(so);
+
+        if (script == null) return;
+
+        var docPath = MusaDocumentBrowser.FindDocForScript(script.name);
+        if (string.IsNullOrEmpty(docPath)) return;
+
+        if (GUILayout.Button("Spec: " + script.name, EditorStyles.linkLabel))
+        {
+            SetSingleDocument(script.name);
+        }
+    }
+
+    // =====================================================================
+    // GUI描画
+    // =====================================================================
+
+    private void OnGUI()
+    {
+        // NOTE: ツールバー（自動更新チェックボックス）
+        EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
+        var newAutoUpdate = GUILayout.Toggle(autoUpdateFromInspector, "インスペクタから自動更新", EditorStyles.toolbarButton, GUILayout.Width(160));
+        if (newAutoUpdate != autoUpdateFromInspector)
+        {
+            autoUpdateFromInspector = newAutoUpdate;
+            if (autoUpdateFromInspector)
+            {
+                // NOTE: ON にした瞬間に現在の選択を反映
+                lastGameObjectInstanceId = 0;
+                OnSelectionChanged();
+            }
+        }
+        GUILayout.FlexibleSpace();
+        EditorGUILayout.EndHorizontal();
+
+        // NOTE: タブモード（GameObjectのコンポーネント一覧）
+        if (docTabs.Count > 0)
+        {
+            DrawTabMode();
+            return;
+        }
+
+        // NOTE: 単一ドキュメントモード
+        DrawSingleMode();
+    }
+
+    // =====================================================================
+    // タブモード描画
+    // =====================================================================
+
+    private void DrawTabMode()
+    {
+        // NOTE: コンポーネント別タブ
+        if (tabNames.Length > 0)
+        {
+            selectedTabIndex = GUILayout.Toolbar(selectedTabIndex, tabNames, GUILayout.Height(24));
+            if (selectedTabIndex < 0 || selectedTabIndex >= docTabs.Count)
+                selectedTabIndex = 0;
+        }
+
+        var tab = docTabs[selectedTabIndex];
+
+        // NOTE: パス表示
+        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+        EditorGUILayout.LabelField(tab.ScriptName, EditorStyles.boldLabel);
+        var specRoot = MusaDocumentBrowser.GetSpecRootPath();
+        var relativePath = tab.DocPath.Replace('\\', '/');
+        var specRootNorm = specRoot.Replace('\\', '/');
+        if (relativePath.StartsWith(specRootNorm))
+            relativePath = "spec" + relativePath.Substring(specRootNorm.Length);
+        EditorGUILayout.LabelField("Path: " + relativePath, EditorStyles.miniLabel);
+        EditorGUILayout.EndVertical();
+
+        EditorGUILayout.Space(2);
+
+        // NOTE: Thaleia描画
+        scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
+        tab.Renderer.Draw();
+        EditorGUILayout.EndScrollView();
+    }
+
+    // =====================================================================
+    // 単一ドキュメント描画
+    // =====================================================================
+
+    private void DrawSingleMode()
+    {
+        // NOTE: ヘッダー
+        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+        EditorGUILayout.LabelField(
+            string.IsNullOrEmpty(currentScriptName) ? "---" : currentScriptName,
+            EditorStyles.boldLabel);
+
+        if (!string.IsNullOrEmpty(currentDocPath))
+        {
+            var specRoot = MusaDocumentBrowser.GetSpecRootPath();
+            var relativePath = currentDocPath.Replace('\\', '/');
+            var specRootNorm = specRoot.Replace('\\', '/');
+            if (relativePath.StartsWith(specRootNorm))
+                relativePath = "spec" + relativePath.Substring(specRootNorm.Length);
+            EditorGUILayout.LabelField("Path: " + relativePath, EditorStyles.miniLabel);
+        }
+        else if (!string.IsNullOrEmpty(currentScriptName))
+        {
+            EditorGUILayout.LabelField("Path: ---", EditorStyles.miniLabel);
+        }
+        EditorGUILayout.EndVertical();
+
+        EditorGUILayout.Space(2);
+
+        // NOTE: コンテンツ
+        if (string.IsNullOrEmpty(currentScriptName))
+        {
+            EditorGUILayout.HelpBox("Projectウインドウでスクリプトを選択、\nまたはInspectorでSpecリンクをクリックしてください", MessageType.Info);
+        }
+        else if (string.IsNullOrEmpty(currentDocPath))
+        {
+            EditorGUILayout.HelpBox("ドキュメントが見つかりません", MessageType.Info);
+        }
+        else
+        {
+            scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
+            singleRenderer.Draw();
+            EditorGUILayout.EndScrollView();
+        }
+    }
+}
+#endif

--- a/unity/Assets/Musa/MusaDocumentWindow.cs.meta
+++ b/unity/Assets/Musa/MusaDocumentWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2fbf11588845c5a4982502e218480e96

--- a/unity/Assets/Musa/ThaleiaRenderer.cs
+++ b/unity/Assets/Musa/ThaleiaRenderer.cs
@@ -1,0 +1,358 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Thaleia — マークダウンをグラフィカルに描画するレンダラー
+/// NOTE: 見出し（色付き背景・フォントサイズ変更・トグル開閉）とリストに対応
+/// </summary>
+public class ThaleiaRenderer
+{
+    // =====================================================================
+    // ブロック定義
+    // =====================================================================
+
+    private enum BlockType
+    {
+        Heading,
+        ListItem,
+        Paragraph,
+        CodeBlock,
+    }
+
+    private class DocBlock
+    {
+        public BlockType Type;
+        public int Level;       // NOTE: Heading: 1-6, ListItem: ネスト深度(0〜)
+        public string Text;
+        public bool IsExpanded;
+    }
+
+    // =====================================================================
+    // フィールド
+    // =====================================================================
+
+    private List<DocBlock> blocks = new List<DocBlock>();
+    private bool stylesInitialized;
+    private GUIStyle h1Style, h2Style, h3Style;
+    private GUIStyle paragraphStyle;
+    private GUIStyle listItemStyle;
+    private GUIStyle codeBlockStyle;
+
+    // NOTE: 見出しレベルごとの背景色
+    private static readonly Color H1Color = new Color(0.20f, 0.40f, 0.65f, 0.85f);
+    private static readonly Color H2Color = new Color(0.25f, 0.50f, 0.45f, 0.70f);
+    private static readonly Color H3Color = new Color(0.40f, 0.35f, 0.55f, 0.55f);
+
+    // =====================================================================
+    // パース
+    // =====================================================================
+
+    /// <summary>
+    /// マークダウンテキストをパースしてブロックリストに変換
+    /// </summary>
+    public void Parse(string markdown)
+    {
+        blocks.Clear();
+        if (string.IsNullOrEmpty(markdown)) return;
+
+        var lines = markdown.Split('\n');
+        bool inCodeBlock = false;
+        var codeBuffer = new System.Text.StringBuilder();
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+
+            // NOTE: コードブロックの開始/終了
+            if (line.TrimStart().StartsWith("```"))
+            {
+                if (inCodeBlock)
+                {
+                    // NOTE: コードブロック終了
+                    blocks.Add(new DocBlock
+                    {
+                        Type = BlockType.CodeBlock,
+                        Text = codeBuffer.ToString(),
+                    });
+                    codeBuffer.Clear();
+                    inCodeBlock = false;
+                }
+                else
+                {
+                    inCodeBlock = true;
+                }
+                continue;
+            }
+
+            if (inCodeBlock)
+            {
+                if (codeBuffer.Length > 0) codeBuffer.Append('\n');
+                codeBuffer.Append(line);
+                continue;
+            }
+
+            // NOTE: 空行はスキップ
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            // NOTE: 見出し
+            if (line.StartsWith("#"))
+            {
+                int level = 0;
+                while (level < line.Length && line[level] == '#') level++;
+                string text = line.Substring(level).Trim();
+                blocks.Add(new DocBlock
+                {
+                    Type = BlockType.Heading,
+                    Level = level,
+                    Text = text,
+                    IsExpanded = true,
+                });
+                continue;
+            }
+
+            // NOTE: リストアイテム（- または * で始まる行）
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("- ") || trimmed.StartsWith("* "))
+            {
+                int indent = line.Length - line.TrimStart().Length;
+                int nestLevel = indent / 2;
+                string text = trimmed.Substring(2);
+                blocks.Add(new DocBlock
+                {
+                    Type = BlockType.ListItem,
+                    Level = nestLevel,
+                    Text = text,
+                });
+                continue;
+            }
+
+            // NOTE: テーブル行（| で始まる）はそのままパラグラフとして表示
+            // NOTE: それ以外の通常テキスト
+            blocks.Add(new DocBlock
+            {
+                Type = BlockType.Paragraph,
+                Text = line,
+            });
+        }
+
+        // NOTE: コードブロックが閉じられなかった場合
+        if (inCodeBlock && codeBuffer.Length > 0)
+        {
+            blocks.Add(new DocBlock
+            {
+                Type = BlockType.CodeBlock,
+                Text = codeBuffer.ToString(),
+            });
+        }
+    }
+
+    // =====================================================================
+    // 描画
+    // =====================================================================
+
+    /// <summary>
+    /// パース済みブロックを描画
+    /// </summary>
+    public void Draw()
+    {
+        InitStyles();
+
+        // NOTE: 現在折りたたまれている見出しレベル（0=折りたたみなし）
+        int collapsedLevel = 0;
+
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            var block = blocks[i];
+
+            // NOTE: 見出しの場合 — 折りたたみ判定をリセットまたは継続
+            if (block.Type == BlockType.Heading)
+            {
+                // NOTE: 折りたたみ中でも同レベル以上の見出しは表示する
+                if (collapsedLevel > 0 && block.Level >= collapsedLevel)
+                {
+                    // NOTE: まだ折りたたみ範囲内 → スキップ
+                    continue;
+                }
+
+                // NOTE: 折りたたみリセット
+                collapsedLevel = 0;
+
+                DrawHeading(block);
+
+                // NOTE: 見出しが閉じられていたら、それ以下のレベルをスキップ
+                if (!block.IsExpanded)
+                {
+                    collapsedLevel = block.Level + 1;
+                }
+                continue;
+            }
+
+            // NOTE: 折りたたみ中はスキップ
+            if (collapsedLevel > 0) continue;
+
+            switch (block.Type)
+            {
+                case BlockType.ListItem:
+                    DrawListItem(block);
+                    break;
+                case BlockType.CodeBlock:
+                    DrawCodeBlock(block);
+                    break;
+                case BlockType.Paragraph:
+                    DrawParagraph(block);
+                    break;
+            }
+        }
+    }
+
+    // =====================================================================
+    // 各ブロックの描画
+    // =====================================================================
+
+    private void DrawHeading(DocBlock block)
+    {
+        var style = block.Level <= 1 ? h1Style : block.Level == 2 ? h2Style : h3Style;
+        var bgColor = block.Level <= 1 ? H1Color : block.Level == 2 ? H2Color : H3Color;
+
+        EditorGUILayout.Space(block.Level <= 1 ? 8 : 4);
+
+        // NOTE: 背景付きの見出し描画
+        var rect = EditorGUILayout.GetControlRect(false, style.fixedHeight > 0 ? style.fixedHeight : style.fontSize + 12);
+        EditorGUI.DrawRect(rect, bgColor);
+
+        // NOTE: トグル三角 + テキスト
+        var foldoutRect = new Rect(rect.x + 4, rect.y, 16, rect.height);
+        var labelRect = new Rect(rect.x + 20, rect.y, rect.width - 24, rect.height);
+
+        // NOTE: Foldoutの三角アイコンを描画
+        block.IsExpanded = EditorGUI.Foldout(foldoutRect, block.IsExpanded, GUIContent.none, true);
+        EditorGUI.LabelField(labelRect, block.Text, style);
+
+        EditorGUILayout.Space(2);
+    }
+
+    private void DrawListItem(DocBlock block)
+    {
+        EditorGUILayout.BeginHorizontal();
+        float indent = 16f + block.Level * 16f;
+        GUILayout.Space(indent);
+
+        // NOTE: ビュレットマーカーの描画
+        var bulletRect = EditorGUILayout.GetControlRect(false, GUILayout.Width(8), GUILayout.Height(EditorGUIUtility.singleLineHeight));
+        var dotRect = new Rect(bulletRect.x, bulletRect.y + bulletRect.height * 0.5f - 2.5f, 5, 5);
+        if (block.Level == 0)
+        {
+            EditorGUI.DrawRect(dotRect, EditorGUIUtility.isProSkin ? Color.white : Color.black);
+        }
+        else
+        {
+            // NOTE: ネストされたリストは丸（中空風に小さい四角）
+            EditorGUI.DrawRect(dotRect, EditorGUIUtility.isProSkin ? new Color(0.7f, 0.7f, 0.7f) : new Color(0.4f, 0.4f, 0.4f));
+        }
+
+        // NOTE: テキスト（**bold** を richText で表現）
+        string richText = ConvertInlineMarkdown(block.Text);
+        EditorGUILayout.LabelField(richText, listItemStyle);
+        EditorGUILayout.EndHorizontal();
+    }
+
+    private void DrawCodeBlock(DocBlock block)
+    {
+        EditorGUILayout.Space(2);
+        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+        EditorGUILayout.TextArea(block.Text, codeBlockStyle, GUILayout.ExpandWidth(true));
+        EditorGUILayout.EndVertical();
+        EditorGUILayout.Space(2);
+    }
+
+    private void DrawParagraph(DocBlock block)
+    {
+        string richText = ConvertInlineMarkdown(block.Text);
+        EditorGUILayout.LabelField(richText, paragraphStyle);
+    }
+
+    // =====================================================================
+    // インラインマークダウン変換
+    // =====================================================================
+
+    /// <summary>
+    /// **bold** と `code` をリッチテキストに変換
+    /// </summary>
+    private static string ConvertInlineMarkdown(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+
+        // NOTE: **bold** → <b>bold</b>
+        text = System.Text.RegularExpressions.Regex.Replace(text, @"\*\*(.+?)\*\*", "<b>$1</b>");
+
+        // NOTE: `code` → <color=#88ccff>code</color>
+        text = System.Text.RegularExpressions.Regex.Replace(text, @"`(.+?)`", "<color=#88ccff>$1</color>");
+
+        return text;
+    }
+
+    // =====================================================================
+    // スタイル初期化
+    // =====================================================================
+
+    private void InitStyles()
+    {
+        if (stylesInitialized) return;
+
+        h1Style = new GUIStyle(EditorStyles.boldLabel)
+        {
+            fontSize = 16,
+            alignment = TextAnchor.MiddleLeft,
+            padding = new RectOffset(4, 4, 2, 2),
+            fixedHeight = 28,
+        };
+        h1Style.normal.textColor = Color.white;
+
+        h2Style = new GUIStyle(EditorStyles.boldLabel)
+        {
+            fontSize = 14,
+            alignment = TextAnchor.MiddleLeft,
+            padding = new RectOffset(4, 4, 2, 2),
+            fixedHeight = 24,
+        };
+        h2Style.normal.textColor = Color.white;
+
+        h3Style = new GUIStyle(EditorStyles.boldLabel)
+        {
+            fontSize = 12,
+            alignment = TextAnchor.MiddleLeft,
+            padding = new RectOffset(4, 4, 2, 2),
+            fixedHeight = 22,
+        };
+        h3Style.normal.textColor = Color.white;
+
+        paragraphStyle = new GUIStyle(EditorStyles.label)
+        {
+            wordWrap = true,
+            richText = true,
+            fontSize = 12,
+            padding = new RectOffset(8, 4, 1, 1),
+        };
+
+        listItemStyle = new GUIStyle(EditorStyles.label)
+        {
+            wordWrap = true,
+            richText = true,
+            fontSize = 12,
+            padding = new RectOffset(2, 4, 1, 1),
+        };
+
+        codeBlockStyle = new GUIStyle(EditorStyles.textArea)
+        {
+            wordWrap = false,
+            richText = false,
+            fontSize = 11,
+            padding = new RectOffset(8, 8, 4, 4),
+        };
+
+        stylesInitialized = true;
+    }
+}
+#endif

--- a/unity/Assets/Musa/ThaleiaRenderer.cs.meta
+++ b/unity/Assets/Musa/ThaleiaRenderer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 968c4dc53f115c346aa1a4225874743e


### PR DESCRIPTION
## Summary
- ThaleiaRenderer: 見出し（色付き背景・トグル開閉）、リスト、コードブロック対応のIMGUIマークダウンレンダラー
- MusaDocumentBrowser: spec/配下のスキャン・スクリプト名→仕様書マッピング
- MusaDocumentExplorer: カテゴリ/ファイルツリー/Thaleia描画の3カラムウインドウ（Musa/Document Explorer）
- MusaDocumentWindow: Inspector連動ドキュメントウインドウ（自動更新タブ・Specリンク）

## Test plan
- [ ] Musa/Document Explorer メニューからウインドウが開けること
- [ ] カテゴリ選択→ファイル選択で仕様書がグラフィカルに表示されること
- [ ] Musa/ドキュメント メニューからドキュメントウインドウが開けること
- [ ] 「インスペクタから自動更新」ON時、GameObjectを選択するとコンポーネントのドキュメントがタブ表示されること
- [ ] InspectorのSpecリンクをクリックしてドキュメントが更新されること
- [ ] コンパイルエラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Unity エディター内でドキュメント参照機能が追加されました。スクリプトに対応する仕様書を専用ウィンドウで閲覧できます。複数ドキュメントのタブ管理、カテゴリー別探索パネル、インスペクターからの直接アクセス、自動更新機能、マークダウン形式のレンダリングが利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->