### PR TITLE
fix: 3チーム分レビュー対応を統合

### DIFF
--- a/unity/Assets/Musa/Melpomene/UI/MelpomeneSetupWizard.cs
+++ b/unity/Assets/Musa/Melpomene/UI/MelpomeneSetupWizard.cs
@@ -78,6 +78,7 @@ namespace Melpomene
         {
             var url = $"{config.ApiBaseUrl}/issues?state=open&per_page=1";
             var request = UnityWebRequest.Get(url);
+            request.timeout = 10;
             request.SetRequestHeader("Authorization", $"Bearer {config.accessToken}");
             request.SetRequestHeader("Accept", "application/vnd.github+json");
             request.SetRequestHeader("User-Agent", "Melpomene-Unity");
@@ -105,6 +106,14 @@ namespace Melpomene
         }
 
         #endregion
+
+        private void OnDisable()
+        {
+            if (!skipWizard) return;
+            var config = MelpomeneConfig.GetOrCreateConfig();
+            config.skipSetupWizard = true;
+            config.SaveLocalSettings();
+        }
 
         private void InitStyles()
         {
@@ -242,13 +251,16 @@ namespace Melpomene
 
             EditorGUILayout.Space(16);
 
-            // PAT入力
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.Space(40);
-            EditorGUILayout.LabelField("PAT", GUILayout.Width(30));
-            patInput = EditorGUILayout.PasswordField(patInput);
-            GUILayout.Space(40);
-            EditorGUILayout.EndHorizontal();
+            // PAT入力（検証中は編集不可）
+            using (new EditorGUI.DisabledGroupScope(isValidating))
+            {
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Space(40);
+                EditorGUILayout.LabelField("PAT", GUILayout.Width(30));
+                patInput = EditorGUILayout.PasswordField(patInput);
+                GUILayout.Space(40);
+                EditorGUILayout.EndHorizontal();
+            }
 
             // エラーメッセージ
             if (!string.IsNullOrEmpty(validationError))
@@ -302,6 +314,7 @@ namespace Melpomene
             validationError = null;
 
             var request = UnityWebRequest.Get("https://api.github.com/user");
+            request.timeout = 10;
             request.SetRequestHeader("Authorization", $"Bearer {patInput}");
             request.SetRequestHeader("User-Agent", "Melpomene-Unity");
 

--- a/unity/Assets/Musa/MusaDocumentBrowser.cs
+++ b/unity/Assets/Musa/MusaDocumentBrowser.cs
@@ -87,7 +87,15 @@ public static class MusaDocumentBrowser
     public static string ReadDocContent(string mdPath)
     {
         if (string.IsNullOrEmpty(mdPath) || !File.Exists(mdPath)) return null;
-        return File.ReadAllText(mdPath);
+        try
+        {
+            return File.ReadAllText(mdPath);
+        }
+        catch (System.Exception ex)
+        {
+            UnityEngine.Debug.LogWarning($"Failed to read doc: {mdPath}\n{ex}");
+            return null;
+        }
     }
 
     /// <summary>
@@ -99,7 +107,6 @@ public static class MusaDocumentBrowser
         var specRoot = GetSpecRootPath();
         if (!Directory.Exists(specRoot)) return;
 
-        var codePath = Path.Combine(specRoot, "code");
         var allMdFiles = Directory.GetFiles(specRoot, "*.md", SearchOption.AllDirectories);
 
         foreach (var mdFile in allMdFiles)

--- a/unity/Assets/Musa/MusaDocumentExplorer.cs
+++ b/unity/Assets/Musa/MusaDocumentExplorer.cs
@@ -101,22 +101,24 @@ public class MusaDocumentExplorer : EditorWindow
         EditorGUILayout.LabelField("Categories", EditorStyles.boldLabel);
         EditorGUILayout.Space(4);
 
-        if (categoryNames == null || categoryNames.Length == 0)
+        var hasCategories = categoryNames != null && categoryNames.Length > 0;
+        if (!hasCategories)
         {
             EditorGUILayout.HelpBox("spec/ が見つかりません", MessageType.Warning);
-            return;
         }
-
-        sidebarScrollPosition = EditorGUILayout.BeginScrollView(sidebarScrollPosition);
-        for (int i = 0; i < categoryNames.Length; i++)
+        else
         {
-            var style = i == selectedCategoryIndex ? sidebarActiveButtonStyle : sidebarButtonStyle;
-            if (GUILayout.Button(categoryNames[i], style))
+            sidebarScrollPosition = EditorGUILayout.BeginScrollView(sidebarScrollPosition);
+            for (int i = 0; i < categoryNames.Length; i++)
             {
-                SelectCategory(i);
+                var style = i == selectedCategoryIndex ? sidebarActiveButtonStyle : sidebarButtonStyle;
+                if (GUILayout.Button(categoryNames[i], style))
+                {
+                    SelectCategory(i);
+                }
             }
+            EditorGUILayout.EndScrollView();
         }
-        EditorGUILayout.EndScrollView();
 
         GUILayout.FlexibleSpace();
 
@@ -124,8 +126,20 @@ public class MusaDocumentExplorer : EditorWindow
         {
             MusaDocumentBrowser.RefreshCache();
             categoryNames = MusaDocumentBrowser.GetCategories();
-            if (selectedCategoryIndex >= 0)
-                SelectCategory(selectedCategoryIndex);
+            var prevIndex = selectedCategoryIndex;
+            selectedCategoryIndex = -1;
+            if (prevIndex >= 0 && prevIndex < categoryNames.Length)
+            {
+                SelectCategory(prevIndex);
+            }
+            else
+            {
+                fileTree.Clear();
+                selectedFilePath = null;
+                fileContent = null;
+                treeScrollPosition = Vector2.zero;
+                contentScrollPosition = Vector2.zero;
+            }
         }
     }
 
@@ -190,7 +204,7 @@ public class MusaDocumentExplorer : EditorWindow
                 {
                     selectedFilePath = node.FullPath;
                     fileContent = MusaDocumentBrowser.ReadDocContent(node.FullPath);
-                    thaleiaRenderer.Parse(fileContent);
+                    thaleiaRenderer.Parse(fileContent ?? string.Empty);
                     contentScrollPosition = Vector2.zero;
                 }
                 EditorGUILayout.EndHorizontal();
@@ -207,6 +221,12 @@ public class MusaDocumentExplorer : EditorWindow
         if (string.IsNullOrEmpty(selectedFilePath))
         {
             EditorGUILayout.HelpBox("ファイルを選択してください", MessageType.Info);
+            return;
+        }
+
+        if (fileContent == null)
+        {
+            EditorGUILayout.HelpBox("ドキュメントの読み込みに失敗しました", MessageType.Warning);
             return;
         }
 

--- a/unity/Assets/Musa/MusaDocumentWindow.cs
+++ b/unity/Assets/Musa/MusaDocumentWindow.cs
@@ -237,6 +237,8 @@ public class MusaDocumentWindow : EditorWindow
 
     private void DrawTabMode()
     {
+        if (docTabs.Count == 0) return;
+
         // NOTE: コンポーネント別タブ
         if (tabNames.Length > 0)
         {

--- a/unity/Assets/Musa/MusaProcessUtility.cs
+++ b/unity/Assets/Musa/MusaProcessUtility.cs
@@ -22,9 +22,14 @@ public static class MusaProcessUtility
             };
             using (var process = Process.Start(psi))
             {
+                if (process == null) return (false, null);
+                // NOTE: WaitForExitを先に呼ぶ（ReadToEndはプロセス終了までブロックするため）
+                if (!process.WaitForExit(5000))
+                {
+                    try { process.Kill(); } catch { /* ignore */ }
+                    return (false, null);
+                }
                 var output = process.StandardOutput.ReadToEnd().Trim();
-                process.StandardError.ReadToEnd();
-                process.WaitForExit(5000);
                 // NOTE: 最初の行だけ取得（gh --versionは複数行出力する場合がある）
                 var firstLine = output.Split('\n')[0].Trim();
                 return (process.ExitCode == 0, firstLine);


### PR DESCRIPTION
## Summary
- 各チームのPRレビュー指摘対応を Foundation develop に統合
- PR #15 (TeamC未対応6件) のベースに、各チームの `foundation-develop-sync` ブランチから追加のレビュー対応を重ねて統合

### PR #15 由来の修正（コミット1）
- **ThaleiaRenderer**: Regexコンパイルキャッシュ化
- **MusaProcessUtility**: 共通プロセス実行ユーティリティ抽出
- **MelpomeneSetupWizard**: GUIStyleキャッシュ化、MusaProcessUtility委譲
- **MusaDocumentWindow**: null防御、NormalizeDocPath共通化
- **MusaWindow**: envWarningStyleキャッシュ、MusaProcessUtility委譲

### チームブランチ由来の修正（コミット2）
- **MelpomeneSetupWizard**: `request.timeout`追加、`OnDisable`保存、PAT入力disable
- **MusaDocumentBrowser**: `ReadDocContent` IO例外処理、未使用変数削除
- **MusaDocumentExplorer**: カテゴリ境界チェック、Refresh安全化、null警告HelpBox
- **MusaDocumentWindow**: `docTabs`空チェック
- **MusaProcessUtility**: `WaitForExit`順序修正、null/timeout防御・`Kill()`

### 除外
- `settings.json` のリポジトリ名変更（チーム固有設定のため除外）

## Test plan
- [ ] Unity Editor で Musa ウインドウが正常に開くことを確認
- [ ] MelpomeneSetupWizard が正常に動作することを確認
- [ ] Document Explorer でカテゴリ選択・Refresh が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ネットワーク接続が遅い場合のタイムアウト処理を改善
  * ファイル読み込み時のエラーハンドリングを強化
  * UI要素のnullチェックとガード条件を追加し、予期しない動作を防止
  * プロセス実行時のタイムアウト機構を導入

* **その他の改善**
  * PAT入力フォームの検証中の編集を防止し、UIテキストを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->